### PR TITLE
Add deepstream parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,22 @@ if(NOT TENSORRT_FOUND)
 endif()
 INCLUDE_DIRECTORIES(${TENSORRT_ROOT}/include)
 
+
+# DeepStream
+if (NOT DEFINED WITH_DEEPSTREAM)
+    set(WITH_DEEPSTREAM false)
+endif ()
+MESSAGE(STATUS "WITH_DEEPSTREAM: ${WITH_DEEPSTREAM}")
+
+if (WITH_DEEPSTREAM)
+    if (NOT DEFINED DeepStream_DIR)
+        set(DeepStream_DIR /opt/nvidia/deepstream/deepstream-5.0)
+    endif ()
+    if (DEFINED DeepStream_DIR)
+        include_directories("${DeepStream_DIR}/sources/includes")
+    endif (DEFINED DeepStream_DIR)
+endif()
+
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/include)
 LINK_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
@@ -63,4 +79,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+
 add_subdirectory (src)

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -38,6 +38,11 @@ add_subdirectory(${PLUGIN_NAME})
 set(INFER_PLUGIN_LIB ${INFER_PLUGIN_LIB} ${PLUGIN_NAME}_static)
 endforeach()
 
+if (WITH_DEEPSTREAM)                                                                                                        
+    MESSAGE(STATUS "Adding NvDsInferParseMmdet")
+    set(INFER_PLUGIN_LIB ${INFER_PLUGIN_LIB} nvinfer_plugin)
+    set(INFER_PLUGIN_SRC ${INFER_PLUGIN_SRC} NvDsInferParseMmdet.cpp)
+endif ()
 
 cuda_add_library(${SHARED_TARGET} SHARED ${INFER_PLUGIN_SRC})
 target_link_libraries(${SHARED_TARGET} ${INFER_PLUGIN_LIB})

--- a/src/plugin/NvDsInferParseMmdet.cpp
+++ b/src/plugin/NvDsInferParseMmdet.cpp
@@ -1,0 +1,111 @@
+#include <cstring>
+#include <iostream>
+#include "nvdsinfer_custom_impl.h"
+
+
+/* This is a sample bounding box parsing function for the mmdetection
+ * detector models converted to TensorRT with https://github.com/grimoire/mmdetection-to-tensorrt. */
+
+/* C-linkage to prevent name-mangling */
+extern "C"
+bool NvDsInferParseMmdet (std::vector<NvDsInferLayerInfo> const &outputLayersInfo,
+        NvDsInferNetworkInfo  const &networkInfo,
+        NvDsInferParseDetectionParams const &detectionParams,
+        std::vector<NvDsInferParseObjectInfo> &objectList)
+{
+  static int numDetectionsIndex = -1;
+  static int boxesLayerIndex = -1;
+  static int scoresLayerIndex = -1;
+  static int classesLayerIndex = -1;
+
+  /* Find the num_detections layer */
+  if (numDetectionsIndex == -1) {
+    for (unsigned int i = 0; i < outputLayersInfo.size(); i++) {
+      if (strcmp(outputLayersInfo[i].layerName, "num_detections") == 0) {
+        numDetectionsIndex = i;
+        break;
+      }
+    }
+    if (numDetectionsIndex == -1) {
+      std::cerr << "Could not find num_detections layer buffer while parsing" << std::endl;
+      return false;
+    }
+  }
+
+  /* Find the boxes layer */
+  if (boxesLayerIndex == -1) {
+    for (unsigned int i = 0; i < outputLayersInfo.size(); i++) {
+      if (strcmp(outputLayersInfo[i].layerName, "boxes") == 0) {
+        boxesLayerIndex = i;
+        break;
+      }
+    }
+    if (boxesLayerIndex == -1) {
+      std::cerr << "Could not find boxes layer buffer while parsing" << std::endl;
+      return false;
+    }
+  }
+
+  /* Find the scores layer */
+  if (scoresLayerIndex == -1) {
+    for (unsigned int i = 0; i < outputLayersInfo.size(); i++) {
+      if (strcmp(outputLayersInfo[i].layerName, "scores") == 0) {
+        scoresLayerIndex = i;
+        break;
+      }
+    }
+    if (scoresLayerIndex == -1) {
+      std::cerr << "Could not find scores layer buffer while parsing" << std::endl;
+      return false;
+    }
+  }
+
+  /* Find the classes layer */
+  if (classesLayerIndex == -1) {
+    for (unsigned int i = 0; i < outputLayersInfo.size(); i++) {
+      if (strcmp(outputLayersInfo[i].layerName, "classes") == 0) {
+        classesLayerIndex = i;
+        break;
+      }
+    }
+    if (classesLayerIndex == -1) {
+      std::cerr << "Could not find classes layer buffer while parsing" << std::endl;
+      return false;
+    }
+  }
+
+  float *bboxes = (float *) outputLayersInfo[boxesLayerIndex].buffer;
+  float *classes = (float *) outputLayersInfo[classesLayerIndex].buffer;
+  float *scores = (float *) outputLayersInfo[scoresLayerIndex].buffer;
+  int numDetsToParse = *((int *) outputLayersInfo[numDetectionsIndex].buffer);
+
+  for (int indx = 0; indx < numDetsToParse; indx++)
+  {
+    float outputX1 = bboxes[indx * 4];
+    float outputY1 = bboxes[indx * 4 + 1];
+    float outputX2 = bboxes[indx * 4 + 2];
+    float outputY2 = bboxes[indx * 4 + 3];
+    float this_class = classes[indx];
+    float this_score = scores[indx];
+    float threshold = detectionParams.perClassThreshold[this_class];
+
+    if (this_score >= threshold)
+    {
+      NvDsInferParseObjectInfo object;
+
+      object.classId = this_class;
+      object.detectionConfidence = this_score;
+
+      object.left = outputX1;
+      object.top = outputY1;
+      object.width = outputX2 - outputX1;
+      object.height = outputY2 - outputY1;
+
+      objectList.push_back(object);
+    }
+  }
+  return true;
+}
+
+/* Check that the custom function has been defined correctly */
+CHECK_CUSTOM_PARSE_FUNC_PROTOTYPE(NvDsInferParseMmdet);


### PR DESCRIPTION
This P.R. allows the usage of models exported with [mmdet2trt](https://github.com/grimoire/mmdetection-to-tensorrt) inside [DeepStream](https://developer.nvidia.com/deepstream-sdk)

It adds a CMAKE option `WITH_DEEPSTREAM`.

Enabling this option will include  a [custom output parser for deepstream](https://docs.nvidia.com/metropolis/deepstream/dev-guide/index.html#page/DeepStream_Development_Guide/deepstream_custom_model.html#wwpID0E0RB0HA) in the shared object library.

To be latter referenced in the [DeepStream configuration file](https://docs.nvidia.com/metropolis/deepstream/dev-guide/index.html#page/DeepStream%20Plugins%20Development%20Guide/deepstream_plugin_details.html#wwpID0E04DB0HA) as the following example:

```
parse-bbox-func-name=NvDsInferParseMmdet
output-blob-names=num_detections;boxes;scores;classes
custom-lib-path=/home/nvidia/amirstan_plugin/build/lib/libamirstan_plugin.so
```
