### PR TITLE
Downgrade cmake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.10)
 project (trt_plugin)
 
 


### PR DESCRIPTION
This eases plugin installation, especially with nvidia containers for deepstream and jetson devices.
- nvcr.io/nvidia/l4t-base:r32.5.0
- nvcr.io/nvidia/deepstream-l4t:5.1-21.02-base

I might be missing some extra requirement but seems to work well with version 3.10