### PR TITLE
Add Conan recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,16 @@ export AMIRSTAN_LIBRARY_PATH=<amirstan_plugin_root>/build/lib
 
 ### Using Conan
 
-- Install [conan](https://conan.io/): 
+- Install [Conan](https://conan.io/): 
 
 ```bash
 pip install conan
+```
+
+- Register grimoire's Conan remote:
+
+```bash
+conan remote add grimoire https://grimoire.jfrog.io/artifactory/api/conan/grimoire-conan
 ```
 
 - Add a `conanfile.txt` file to your project's root with the following content:

--- a/README.md
+++ b/README.md
@@ -62,13 +62,35 @@ pip install conan
 
 - Add a `conanfile.txt` file to your project's root with the following content:
 
-```bash
+```
 [requires]
 amirstan_plugin/0.4.1
 
 [generators]
 cmake
 ```
+
+- Additionaly, you can add a few options under the \[options\] section to configure your build:
+
+  * tensorrt_dir: path where TensorRT is located. Default `~/SDK/TensorRT`.
+  * with_deepstream: whether to compile with deepstream support. Default `False`.
+  * deepstream_dir: path where deepstream is located. Default `/opt/nvidia/deepstream/deepstream`
+  * cub_root_dir: Default `./third_party/cub`
+  * cuda_arch: list of CUDA architectures to compile for. Default `61;62;70;72;75;80;86`
+
+  For example, to use a custom TensorRT dir and compile for a specific CUDA architecture:
+
+  ```
+  [requires]
+  amirstan_plugin/0.4.1
+
+  [generators]
+  cmake
+
+  [options]
+  amirstan_plugin:tensorrt_dir=/usr/include/x86_64-linux-gnu
+  amirstan_plugin:cuda_arch=75
+  ```
 
 - Add the following lines to your project root's `CMakeLists.txt`:
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ INCLUDE(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 CONAN_BASIC_SETUP()
 ```
 
+- Add conan libs to the linking stage:
+
+```
+target_link_libraries(trt_sample PUBLIC ${CONAN_LIBS} ${CUDA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${TensorRT_LIBRARIES})
+```
+
 - Compile your project:
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ https://github.com/grimoire/mmdetection-to-tensorrt
 
 - Install tensorrt7: https://developer.nvidia.com/tensorrt
 
+### From sources
+
 clone the repo and create build folder
 
 ```shell
@@ -50,3 +52,37 @@ set the envoirment variable(in ~/.bashrc):
 export AMIRSTAN_LIBRARY_PATH=<amirstan_plugin_root>/build/lib
 ```
 
+### Using Conan
+
+- Install [conan](https://conan.io/): 
+
+```bash
+pip install conan
+```
+
+- Add a `conanfile.txt` file to your project's root with the following content:
+
+```bash
+[requires]
+amirstan_plugin/0.4.1
+
+[generators]
+cmake
+```
+
+- Add the following lines to your project root's `CMakeLists.txt`:
+
+```
+INCLUDE(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+CONAN_BASIC_SETUP()
+```
+
+- Compile your project:
+
+```
+$ mkdir build
+$ cd build
+$ conan install .. -s compiler.libcxx=libstdc++11 --build=missing 
+$ cmake .. 
+$ make -j${nproc}
+```

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,8 +1,8 @@
 from conans import ConanFile, CMake
 
 
-class AmirstanConan(ConanFile):
-    name = "amirstan"
+class AmirstanPluginConan(ConanFile):
+    name = "amirstan_plugin"
     version = "0.4.1"
     license = "MIT"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,42 @@
+from conans import ConanFile, CMake
+
+
+class AmirstanConan(ConanFile):
+    name = "amirstan"
+    version = "0.4.1"
+    license = "MIT"
+
+    url = "https://github.com/grimoire/amirstan_plugin.git"
+    repo_url = "https://github.com/grimoire/amirstan_plugin.git"
+    description = "Amirstan plugin contain some useful tensorrt plugin."
+    topics = ("tensorrt", "mmdetection")
+    settings = "os", "compiler", "build_type", "arch"
+    options = { 
+        "shared": [True, False],
+        "cuda_arch": ["61;62;70;72;75;80;86","61","62","70","72","75","80","86"]
+    }
+    default_options = { "shared": True,
+                        "cuda_arch": "61;62;70;72;75;80;86"}
+    generators = "cmake"
+    exports_sources = "src*", "include*", "lib*", "CMakeLists.txt", "cmake*"
+
+    def configure(self):
+        self.settings.compiler.libcxx = "libstdc++11"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.definitions['GPU_ARCHS'] = self.options.cuda_arch
+        cmake.configure(source_folder=".")
+        cmake.build()
+
+    def package(self):
+        self.copy("*.h", dst="include/plugin", src="include/plugin")
+        self.copy("*.h", dst="include/amir_cuda_util", src="include/amir_cuda_util")
+        self.copy("*.lib", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.dylib*", dst="lib", keep_path=False)
+        self.copy("*.so*", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+    
+    def package_info(self):
+        self.cpp_info.libs = ["amirstan_plugin"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,10 +13,20 @@ class AmirstanPluginConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     options = { 
         "shared": [True, False],
-        "cuda_arch": ["61;62;70;72;75;80;86","61","62","70","72","75","80","86"]
+        "tensorrt_dir": "ANY",
+        "with_deepstream": [True, False],
+        "deepstream_dir": "ANY",
+        "cub_root_dir": "ANY",
+        "cuda_arch": "ANY"
     }
-    default_options = { "shared": True,
-                        "cuda_arch": "61;62;70;72;75;80;86"}
+    default_options = { 
+        "shared": True,
+        "tensorrt_dir": None,
+        "with_deepstream": False,
+        "deepstream_dir": None,
+        "cub_root_dir": None,
+        "cuda_arch": "61;62;70;72;75;80;86"
+    }
     generators = "cmake"
     exports_sources = "src*", "include*", "lib*", "CMakeLists.txt", "cmake*"
 
@@ -25,7 +35,19 @@ class AmirstanPluginConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+
+        cmake.definitions["WITH_DEEPSTREAM"] = self.options.with_deepstream
         cmake.definitions['GPU_ARCHS'] = self.options.cuda_arch
+
+        if self.options.tensorrt_dir is not None:
+            cmake.definitions["TENSORRT_DIR"] = self.options.tensorrt_dir
+
+        if self.options.deepstream_dir is not None and self.options.with_deepstream:
+            cmake.definitions["DeepStream_DIR"] = self.options.deepstream_dir
+        
+        if self.options.cub_root_dir is not None:
+            cmake.definitions["CUB_ROOT_DIR"] = self.options.cub_root_dir
+
         cmake.configure(source_folder=".")
         cmake.build()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,17 +36,17 @@ class AmirstanPluginConan(ConanFile):
     def build(self):
         cmake = CMake(self)
 
-        cmake.definitions["WITH_DEEPSTREAM"] = self.options.with_deepstream
-        cmake.definitions['GPU_ARCHS'] = self.options.cuda_arch
+        cmake.definitions["WITH_DEEPSTREAM"] = self.options.with_deepstream.value
+        cmake.definitions['GPU_ARCHS'] = self.options.cuda_arch.value
 
-        if self.options.tensorrt_dir is not None:
-            cmake.definitions["TENSORRT_DIR"] = self.options.tensorrt_dir
+        if self.options.tensorrt_dir.value != "None":
+            cmake.definitions["TENSORRT_DIR"] = self.options.tensorrt_dir.value
 
-        if self.options.deepstream_dir is not None and self.options.with_deepstream:
-            cmake.definitions["DeepStream_DIR"] = self.options.deepstream_dir
+        if self.options.deepstream_dir != "None" and self.options.with_deepstream.value:
+            cmake.definitions["DeepStream_DIR"] = self.options.deepstream_dir.value
         
-        if self.options.cub_root_dir is not None:
-            cmake.definitions["CUB_ROOT_DIR"] = self.options.cub_root_dir
+        if self.options.cub_root_dir != "None":
+            cmake.definitions["CUB_ROOT_DIR"] = self.options.cub_root_dir.value
 
         cmake.configure(source_folder=".")
         cmake.build()


### PR DESCRIPTION
[Conan](https://conan.io/) is one of the most used package managers in C++.

I added the recipe so it can be automatically updated and uploaded using a CI pipeline. This should help the user since the compilation is automatic and there is no need export any path.

There are a few things that need to be done on your side:
* Install conan: `pip install conan`
* Create an account at JFrog (free): https://jfrog.com/start-free/
* Create a conan channel (free): 
![image](https://user-images.githubusercontent.com/6081282/126978573-eedd422d-3f07-467e-bebf-8f208a2cf584.png)
![image](https://user-images.githubusercontent.com/6081282/126978648-d61f26c1-5e45-491c-b948-8811bc789ab7.png)
* Enable anonymous access:
![image](https://user-images.githubusercontent.com/6081282/126980361-c810d1d7-baaf-438d-a2c0-2a9bd0223291.png)
* Add your channel as a remote:  E.g., `conan remote add sbugallo https://sbugallo.jfrog.io/artifactory/api/conan/sbugallo-conan`
* Create you package locally: `conan create .`
* Upload package: E.g., `conan upload amirstan_plugin -r sbugallo --all`

I uploaded it to my own channel (and you can test it if you want) but I think it would be better to integrate it in the official repository.